### PR TITLE
feat: ensure group writable files

### DIFF
--- a/flow2src/flow2src.js
+++ b/flow2src/flow2src.js
@@ -222,12 +222,12 @@ module.exports = function(RED) {
                             // Create the src path
                             let sFPath = sF.file.delRightMost('/');
                             if (!fs.existsSync(sFPath)) {
-                                fs.mkdirSync(sFPath, { recursive: true });
+                                fs.mkdirSync(sFPath, { recursive: true, mode: 0o775 });
                             }
 
                             // Write the given file
                             if (obj[sF.property] != '') {
-                                fs.writeFileSync(sF.file, obj[sF.property]);
+                                fs.writeFileSync(sF.file, obj[sF.property], { mode: 0o664 });
                                 sF.file = sF.file.delLeftMost(path + '/');
                                 manifest.push(sF);
                             }
@@ -235,8 +235,8 @@ module.exports = function(RED) {
                     });
 
                     // Write the manifest to the src folder
-                    fs.mkdirSync(path, { recursive: true });
-                    fs.writeFileSync(path + '/manifest.json', JSON.stringify(manifest, null, 4));
+                    fs.mkdirSync(path, { recursive: true, mode: 0o775 });
+                    fs.writeFileSync(path + '/manifest.json', JSON.stringify(manifest, null, 4), { mode: 0o664 });
                     node.status({ fill: "green", shape: "dot", text: "updated files" });
                     setTimeout(function() {
                         node.status({});
@@ -265,7 +265,7 @@ module.exports = function(RED) {
                     });
 
                     // Update the flow file
-                    fs.writeFileSync(flowFile, JSON.stringify(ff, null, 4));
+                    fs.writeFileSync(flowFile, JSON.stringify(ff, null, 4), { mode: 0o664 });
                 } catch(e) {
                     node.error(e);
                 }

--- a/src/flow2src/nodemakerjs.js
+++ b/src/flow2src/nodemakerjs.js
@@ -222,12 +222,12 @@ module.exports = function(RED) {
                             // Create the src path
                             let sFPath = sF.file.delRightMost('/');
                             if (!fs.existsSync(sFPath)) {
-                                fs.mkdirSync(sFPath, { recursive: true });
+                                fs.mkdirSync(sFPath, { recursive: true, mode: 0o775 });
                             }
 
                             // Write the given file
                             if (obj[sF.property] != '') {
-                                fs.writeFileSync(sF.file, obj[sF.property]);
+                                fs.writeFileSync(sF.file, obj[sF.property], { mode: 0o664 });
                                 sF.file = sF.file.delLeftMost(path + '/');
                                 manifest.push(sF);
                             }
@@ -235,7 +235,7 @@ module.exports = function(RED) {
                     });
 
                     // Write the manifest to the src folder
-                    fs.writeFileSync(path + '/manifest.json', JSON.stringify(manifest, null, 4));
+                    fs.writeFileSync(path + '/manifest.json', JSON.stringify(manifest, null, 4), { mode: 0o664 });
                     node.status({ fill: "green", shape: "dot", text: "updated files" });
                     setTimeout(function() {
                         node.status({});
@@ -264,7 +264,7 @@ module.exports = function(RED) {
                     });
 
                     // Update the flow file
-                    fs.writeFileSync(flowFile, JSON.stringify(ff, null, 4));
+                    fs.writeFileSync(flowFile, JSON.stringify(ff, null, 4), { mode: 0o664 });
                 } catch(e) {
                     node.error(e);
                 }


### PR DESCRIPTION
## Summary
- ensure src folders and files are created with group-writable permissions
- propagate the same permission options to compiled flow2src

## Testing
- `npm test` *(fails: Missing script "test")*
- `node test script` to generate a flow and verify directory `775` and file `664` modes


------
https://chatgpt.com/codex/tasks/task_e_6892171df65883308ccf5555f3d26689