### PR TITLE
feat: add subflow folder option

### DIFF
--- a/flow2src/flow2src.html
+++ b/flow2src/flow2src.html
@@ -147,7 +147,14 @@
             <div class="col-100">
                 <label for="node-input-srcFolder">Output Folder</label>
                 <input type="text" id="node-input-srcFolder" placeholder="src">
-                
+
+            </div><!--col-->
+        </div><!--form-row-->
+        <div class="form-row">
+            <div class="col-100">
+                <label for="node-input-subflowFolder">Subflow Folder</label>
+                <input type="text" id="node-input-subflowFolder" placeholder="">
+
             </div><!--col-->
         </div><!--form-row-->
         <div class="form-row">
@@ -204,6 +211,7 @@ options:
 subflows.
 * Output Folder - By default the folder is named 'src'; you can specify a different path relative to your project's flow
 file.
+* Subflow Folder - Optional folder for subflows; defaults to Output Folder when left blank.
 
 Lastly, you can invoke the "Flow-to-Src" button automatically using the checkbox for "Automatiaclly Flow-to-Src on
 Deploys".
@@ -218,6 +226,7 @@ Deploys".
                         incFlows: {value:"*"},
             incSubflows: {value:"*"},
             srcFolder: {value:"src"},
+            subflowFolder: {value:""},
             chkAutoFlow2Src: {value:false}
         },
         inputs: 0,
@@ -237,7 +246,7 @@ Deploys".
             }, 30);
             var node = this;
             $('#btn_flow2src').click(function(){
-                doAjax({"action":'flow2src', "srcFolder": node.srcFolder}, node.id, function(res){
+                doAjax({"action":'flow2src', "srcFolder": node.srcFolder, "subflowFolder": node.subflowFolder}, node.id, function(res){
                     $('#node-dialog-ok').click();
                     let notice = RED.notify('Flow source properties written to "./' + node.srcFolder + '" folder.', {
                         type: "success",
@@ -246,7 +255,7 @@ Deploys".
                 });
             });
             $('#btn_src2flow').click(function(){
-                doAjax({"action":'src2flow', "srcFolder": node.srcFolder}, node.id, function(res) {
+                doAjax({"action":'src2flow', "srcFolder": node.srcFolder, "subflowFolder": node.subflowFolder}, node.id, function(res) {
                     reloadFlows(function() {
                         $('#node-dialog-ok').click();
                     });

--- a/src/flow2src/nodemakerhtml.html
+++ b/src/flow2src/nodemakerhtml.html
@@ -49,6 +49,7 @@ options:
 subflows.
 * Output Folder - By default the folder is named 'src'; you can specify a different path relative to your project's flow
 file.
+* Subflow Folder - Optional folder for subflows; defaults to Output Folder when left blank.
 
 Lastly, you can invoke the "Flow-to-Src" button automatically using the checkbox for "Automatiaclly Flow-to-Src on
 Deploys".
@@ -60,7 +61,8 @@ Deploys".
         color: '{{node_color}}',
         defaults: {
             name: {value:""},
-            {{{defaults}}}
+            {{{defaults}}},
+            subflowFolder: {value:""}
         },
         inputs: {{numinputs}},
         outputs: {{numoutputs}},
@@ -75,7 +77,7 @@ Deploys".
             {{{oneditprepare}}}
             var node = this;
             $('#btn_flow2src').click(function(){
-                doAjax({"action":'flow2src', "srcFolder": node.srcFolder}, node.id, function(res){
+                doAjax({"action":'flow2src', "srcFolder": node.srcFolder, "subflowFolder": node.subflowFolder}, node.id, function(res){
                     $('#node-dialog-ok').click();
                     let notice = RED.notify('Flow source properties written to "./' + node.srcFolder + '" folder.', {
                         type: "success",
@@ -84,7 +86,7 @@ Deploys".
                 });
             });
             $('#btn_src2flow').click(function(){
-                doAjax({"action":'src2flow', "srcFolder": node.srcFolder}, node.id, function(res) {
+                doAjax({"action":'src2flow', "srcFolder": node.srcFolder, "subflowFolder": node.subflowFolder}, node.id, function(res) {
                     reloadFlows(function() {
                         $('#node-dialog-ok').click();
                     });


### PR DESCRIPTION
## Summary
- add Subflow Folder field and default option
- send subflowFolder in AJAX calls and document usage
- mirror changes in Node Maker template

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68921993438c8330897378641486bbe3