### PR TITLE
feat: support separate subflow folder

### DIFF
--- a/flow2src/flow2src.html
+++ b/flow2src/flow2src.html
@@ -147,7 +147,21 @@
             <div class="col-100">
                 <label for="node-input-srcFolder">Output Folder</label>
                 <input type="text" id="node-input-srcFolder" placeholder="src">
-                
+
+            </div><!--col-->
+        </div><!--form-row-->
+        <div class="form-row">
+            <div class="col-100 reg-lbl">
+                <label class="full-lbl">
+                    <span>The subflow output folder relative to the flow file (defaults to Output Folder):</span>
+                </label>
+            </div><!--col-->
+        </div><!--form-row-->
+        <div class="form-row">
+            <div class="col-100">
+                <label for="node-input-subflowFolder">Subflow Folder</label>
+                <input type="text" id="node-input-subflowFolder" placeholder="src">
+
             </div><!--col-->
         </div><!--form-row-->
         <div class="form-row">
@@ -204,6 +218,7 @@ options:
 subflows.
 * Output Folder - By default the folder is named 'src'; you can specify a different path relative to your project's flow
 file.
+* Subflow Folder - Specify a different path for subflows; defaults to Output Folder when left blank.
 
 Lastly, you can invoke the "Flow-to-Src" button automatically using the checkbox for "Automatiaclly Flow-to-Src on
 Deploys".
@@ -218,6 +233,7 @@ Deploys".
                         incFlows: {value:"*"},
             incSubflows: {value:"*"},
             srcFolder: {value:"src"},
+            subflowFolder: {value:""},
             chkAutoFlow2Src: {value:false}
         },
         inputs: 0,
@@ -237,7 +253,7 @@ Deploys".
             }, 30);
             var node = this;
             $('#btn_flow2src').click(function(){
-                doAjax({"action":'flow2src', "srcFolder": node.srcFolder}, node.id, function(res){
+                doAjax({"action":'flow2src', "srcFolder": node.srcFolder, "subflowFolder": node.subflowFolder}, node.id, function(res){
                     $('#node-dialog-ok').click();
                     let notice = RED.notify('Flow source properties written to "./' + node.srcFolder + '" folder.', {
                         type: "success",
@@ -246,7 +262,7 @@ Deploys".
                 });
             });
             $('#btn_src2flow').click(function(){
-                doAjax({"action":'src2flow', "srcFolder": node.srcFolder}, node.id, function(res) {
+                doAjax({"action":'src2flow', "srcFolder": node.srcFolder, "subflowFolder": node.subflowFolder}, node.id, function(res) {
                     reloadFlows(function() {
                         $('#node-dialog-ok').click();
                     });

--- a/src/flow2src/nodemakerhtml.html
+++ b/src/flow2src/nodemakerhtml.html
@@ -49,6 +49,7 @@ options:
 subflows.
 * Output Folder - By default the folder is named 'src'; you can specify a different path relative to your project's flow
 file.
+* Subflow Folder - Specify a different path for subflows; defaults to Output Folder when left blank.
 
 Lastly, you can invoke the "Flow-to-Src" button automatically using the checkbox for "Automatiaclly Flow-to-Src on
 Deploys".
@@ -75,7 +76,7 @@ Deploys".
             {{{oneditprepare}}}
             var node = this;
             $('#btn_flow2src').click(function(){
-                doAjax({"action":'flow2src', "srcFolder": node.srcFolder}, node.id, function(res){
+                doAjax({"action":'flow2src', "srcFolder": node.srcFolder, "subflowFolder": node.subflowFolder}, node.id, function(res){
                     $('#node-dialog-ok').click();
                     let notice = RED.notify('Flow source properties written to "./' + node.srcFolder + '" folder.', {
                         type: "success",
@@ -84,7 +85,7 @@ Deploys".
                 });
             });
             $('#btn_src2flow').click(function(){
-                doAjax({"action":'src2flow', "srcFolder": node.srcFolder}, node.id, function(res) {
+                doAjax({"action":'src2flow', "srcFolder": node.srcFolder, "subflowFolder": node.subflowFolder}, node.id, function(res) {
                     reloadFlows(function() {
                         $('#node-dialog-ok').click();
                     });

--- a/src/flow2src/nodemakerjs.js
+++ b/src/flow2src/nodemakerjs.js
@@ -5,6 +5,9 @@ module.exports = function(RED) {
         node.on('input', function (msg) {
             if (!msg.hasOwnProperty('srcFolder')) return;
             if (msg.srcFolder.trim() == '') msg.srcFolder = 'src';
+            if (!msg.hasOwnProperty('subflowFolder') || msg.subflowFolder.trim() == '') {
+                msg.subflowFolder = msg.srcFolder;
+            }
 
             // String manipulation functions
             (function () {
@@ -70,7 +73,9 @@ module.exports = function(RED) {
 
             // Read and parse the flow file
             let ff = JSON.parse(fs.readFileSync(flowFile).toString());
-            let path = flowFile.delRightMost('/') + '/' + msg.srcFolder;
+            let basePath = flowFile.delRightMost('/');
+            let flowPath = basePath + '/' + msg.srcFolder;
+            let subflowPath = basePath + '/' + msg.subflowFolder;
 
             // Write the relevant flow properties to the src folder
             if (msg.action == 'flow2src') {
@@ -92,8 +97,7 @@ module.exports = function(RED) {
 
                     // Gather flow ids, folder safe names, and nodes for analysis in a single pass
                     let theNodes = [];
-                    let theFolders = [];
-                    let theIDs = [];
+                    let idMap = {};
                     ff.forEach(function (obj) {
 
                         // Check for matching flows
@@ -103,8 +107,7 @@ module.exports = function(RED) {
                                     return;
                                 }
                             }
-                            theFolders.push(obj.label.replace(/[^a-z0-9]/gi, '_'));
-                            theIDs.push(obj.id);
+                            idMap[obj.id] = { folder: obj.label.replace(/[^a-z0-9]/gi, '_'), subflow: false };
                         }
 
                         // Check for matching subflows
@@ -114,8 +117,7 @@ module.exports = function(RED) {
                                     return;
                                 }
                             }
-                            theFolders.push(obj.name.replace(/[^a-z0-9]/gi, '_'));
-                            theIDs.push(obj.id);
+                            idMap[obj.id] = { folder: obj.name.replace(/[^a-z0-9]/gi, '_'), subflow: true };
                         }
                         // Gather nodes and templates
                         if (obj.type == 'template' || obj.type == 'function' || obj.type == 'wp function') {
@@ -127,8 +129,9 @@ module.exports = function(RED) {
                     let existingFiles = [];
                     let srcNodes = [];
                     theNodes.forEach(function (obj) {
-                        if (theIDs.indexOf(obj.z) == -1) return;
-                        
+                        if (!idMap.hasOwnProperty(obj.z)) return;
+                        let info = idMap[obj.z];
+
                         // Determine the filename extension
                         let ext = '';
                         if (obj.type == 'template') {
@@ -159,12 +162,13 @@ module.exports = function(RED) {
                             ext = '.' + fname.getRightMost('.');
                             fname = fname.delRightMost('.');
                         }
-                        let file = path + '/' + theFolders[theIDs.indexOf(obj.z)] + '/' + fname + ext;
+                        let base = info.subflow ? subflowPath : flowPath;
+                        let file = base + '/' + info.folder + '/' + fname + ext;
                         let i = 2;
 
                         // Iterate existing filenames
                         while (existingFiles.indexOf(file) != -1) {
-                            file = path + '/' + theFolders[theIDs.indexOf(obj.z)] + '/' + fname + i.toString() + ext;
+                            file = base + '/' + info.folder + '/' + fname + i.toString() + ext;
                             i++;
                         }
                         obj.srcFiles = [];
@@ -172,14 +176,16 @@ module.exports = function(RED) {
                             obj.srcFiles.push({
                                 id: obj.id,
                                 property: 'template',
-                                file: file
+                                file: file,
+                                subflow: info.subflow
                             });
                             existingFiles.push(file);
                         } else if (obj.type == 'function') {
                             obj.srcFiles.push({
                                 id: obj.id,
                                 property: 'func',
-                                file: file
+                                file: file,
+                                subflow: info.subflow
                             });
                             existingFiles.push(file);
 
@@ -190,7 +196,8 @@ module.exports = function(RED) {
                             obj.srcFiles.push({
                                 id: obj.id,
                                 property: 'initialize',
-                                file: onStartFile
+                                file: onStartFile,
+                                subflow: info.subflow
                             });
                             let onStopFile = file;
                             ext = onStopFile.getRightMost('.');
@@ -198,21 +205,30 @@ module.exports = function(RED) {
                             obj.srcFiles.push({
                                 id: obj.id,
                                 property: 'finalize',
-                                file: onStopFile
+                                file: onStopFile,
+                                subflow: info.subflow
                             });
                         } else if (obj.type == 'wp function') {
                             obj.srcFiles.push({
                                 id: obj.id,
                                 property: 'func',
-                                file: file
+                                file: file,
+                                subflow: info.subflow
                             });
                             existingFiles.push(file);
                         }
                         srcNodes.push(obj);
                     });
 
-                    // Remove prior src folder
-                    fs.rmSync(path, { recursive: true, force: true });
+                    // Remove prior src folders
+                    fs.rmSync(flowPath, { recursive: true, force: true });
+                    if (subflowPath !== flowPath) {
+                        fs.rmSync(subflowPath, { recursive: true, force: true });
+                    }
+                    fs.mkdirSync(flowPath, { recursive: true, mode: 0o775 });
+                    if (subflowPath !== flowPath) {
+                        fs.mkdirSync(subflowPath, { recursive: true, mode: 0o775 });
+                    }
 
                     // Write the nodes to the src folder and record the manifest
                     let manifest = [];
@@ -228,14 +244,16 @@ module.exports = function(RED) {
                             // Write the given file
                             if (obj[sF.property] != '') {
                                 fs.writeFileSync(sF.file, obj[sF.property], { mode: 0o664 });
-                                sF.file = sF.file.delLeftMost(path + '/');
+                                let base = sF.subflow ? subflowPath : flowPath;
+                                sF.file = sF.file.delLeftMost(base + '/');
                                 manifest.push(sF);
                             }
                         });
                     });
 
                     // Write the manifest to the src folder
-                    fs.writeFileSync(path + '/manifest.json', JSON.stringify(manifest, null, 4), { mode: 0o664 });
+                    fs.mkdirSync(flowPath, { recursive: true, mode: 0o775 });
+                    fs.writeFileSync(flowPath + '/manifest.json', JSON.stringify(manifest, null, 4), { mode: 0o664 });
                     node.status({ fill: "green", shape: "dot", text: "updated files" });
                     setTimeout(function() {
                         node.status({});
@@ -250,15 +268,16 @@ module.exports = function(RED) {
                 try {
 
                     // Load the manifest
-                    if (!fs.existsSync(path + '/manifest.json')) return;
-                    let mn = JSON.parse(fs.readFileSync(path + '/manifest.json').toString());
+                    if (!fs.existsSync(flowPath + '/manifest.json')) return;
+                    let mn = JSON.parse(fs.readFileSync(flowPath + '/manifest.json').toString());
 
                     ff.forEach(function (obj) {
                         mn.forEach(function(item) {
                             if (item.id != obj.id) return;
                             
                             // Update the content from the external file
-                            let file = fs.readFileSync(path + '/' + item.file).toString();
+                            let base = item.subflow ? subflowPath : flowPath;
+                            let file = fs.readFileSync(base + '/' + item.file).toString();
                             obj[item.property] = file;
                         });
                     });
@@ -273,7 +292,7 @@ module.exports = function(RED) {
 
         // Automatic flow2src on deploys
         if (config.chkAutoFlow2Src) {
-            node.receive({action:"flow2src", srcFolder: config.srcFolder});
+            node.receive({action:"flow2src", srcFolder: config.srcFolder, subflowFolder: config.subflowFolder});
         }
     }
     RED.httpAdmin.post("/flow2src/:id", RED.auth.needsPermission("inject.write"), function (req, res) {


### PR DESCRIPTION
## Summary
- allow specifying a separate folder for subflow sources
- record subflow flag in manifest and resolve paths during Src-to-Flow
- update templates and editor UI for subflow support

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6892199ec8b883309f0bfd14df45c95f